### PR TITLE
fix typos in comments

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -65,7 +65,7 @@ func main() {
 	{
 		cmd := ecs.NewCommandQueue(world)
 
-		// You can add observer handlers which run as a result of triggerred events
+		// You can add observer handlers which run as a result of triggered events
 		world.AddObserver(
 			ecs.NewHandler(func(trigger ecs.Trigger[PrintMessage]) {
 				fmt.Println("Observer 1:", trigger.Data.Msg)
@@ -102,7 +102,7 @@ func main() {
 	// Also, add render systems if you want, These run as fast as possible
 	// scheduler.AppendRender()
 
-	// This will block until the scheduler exits `scheudler.SetQuit(true)`
+	// This will block until the scheduler exits `scheduler.SetQuit(true)`
 	scheduler.Run()
 }
 
@@ -135,7 +135,7 @@ func MoveSystemOption_A(world *ecs.World) ecs.System {
 }
 
 // Option 2: Define a system and have all the queries created and injected for you
-// - Can be used for simpler systems that dont need to track much system-internal state
+// - Can be used for simpler systems that don't need to track much system-internal state
 // - Use the `ecs.NewSystemN(world, systemFunction)` syntax (Where N represents the number of required resources)
 func MoveSystemOption_B(dt time.Duration, query *ecs.View2[Position, Velocity]) {
 	query.MapId(func(id ecs.Id, pos *Position, vel *Velocity) {

--- a/view_gen.go
+++ b/view_gen.go
@@ -19,7 +19,7 @@ type View1[A any] struct {
 	storageA *componentStorage[A]
 }
 
-// implement the intializer interface so that it can be automatically created and injected into systems
+// implement the initializer interface so that it can be automatically created and injected into systems
 func (v *View1[A]) initialize(world *World) any {
 	// TODO: filters need to be a part of the query type
 	return Query1[A](world)


### PR DESCRIPTION
Was looking through your code to use as an example for building my own ECS. I found some typos and thought I'd fix them as a small thanks for the example :) 

If you are using visual studio code, I can recommend this extension to catch spelling mistakes: https://marketplace.visualstudio.com/items/?itemName=streetsidesoftware.code-spell-checker